### PR TITLE
Enable editing workflows and refresh task UI

### DIFF
--- a/TodoListApp/TodoListApp.xcodeproj/project.pbxproj
+++ b/TodoListApp/TodoListApp.xcodeproj/project.pbxproj
@@ -28,7 +28,8 @@
 		A10000172000000000000001 /* FetchTasksUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000162000000000000001 /* FetchTasksUseCase.swift */; };
 		A10000192000000000000001 /* GetTaskByIDUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000182000000000000001 /* GetTaskByIDUseCase.swift */; };
 		A100001B2000000000000001 /* AddTaskUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100001A2000000000000001 /* AddTaskUseCase.swift */; };
-		A100001D2000000000000001 /* UpdateTaskStatusUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100001C2000000000000001 /* UpdateTaskStatusUseCase.swift */; };
+                A100001D2000000000000001 /* UpdateTaskUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100001C2000000000000001 /* UpdateTaskUseCase.swift */; };
+                D10000022000000000000001 /* UpdateTaskListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000012000000000000001 /* UpdateTaskListUseCase.swift */; };
 		A100001F2000000000000001 /* TaskRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100001E2000000000000001 /* TaskRepositoryImpl.swift */; };
 		A10000252000000000000001 /* TaskDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000242000000000000001 /* TaskDataModel.swift */; };
 		A10000272000000000000001 /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000262000000000000001 /* PersistenceController.swift */; };
@@ -77,7 +78,8 @@
 		A10000162000000000000001 /* FetchTasksUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchTasksUseCase.swift; sourceTree = "<group>"; };
 		A10000182000000000000001 /* GetTaskByIDUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTaskByIDUseCase.swift; sourceTree = "<group>"; };
 		A100001A2000000000000001 /* AddTaskUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskUseCase.swift; sourceTree = "<group>"; };
-		A100001C2000000000000001 /* UpdateTaskStatusUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateTaskStatusUseCase.swift; sourceTree = "<group>"; };
+                A100001C2000000000000001 /* UpdateTaskUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateTaskUseCase.swift; sourceTree = "<group>"; };
+                D10000012000000000000001 /* UpdateTaskListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateTaskListUseCase.swift; sourceTree = "<group>"; };
 		A100001E2000000000000001 /* TaskRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRepositoryImpl.swift; sourceTree = "<group>"; };
 		A10000242000000000000001 /* TaskDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDataModel.swift; sourceTree = "<group>"; };
 		A10000262000000000000001 /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
@@ -272,11 +274,12 @@
 			children = (
 				A10000162000000000000001 /* FetchTasksUseCase.swift */,
 				A10000182000000000000001 /* GetTaskByIDUseCase.swift */,
-				A100001A2000000000000001 /* AddTaskUseCase.swift */,
-				B10000092000000000000001 /* AddTaskListUseCase.swift */,
-				A100001C2000000000000001 /* UpdateTaskStatusUseCase.swift */,
-				7669B43A71CB49D2B98BA1913776AD96 /* DeleteTaskUseCase.swift */,
-				B100000B2000000000000001 /* DeleteTaskListUseCase.swift */,
+                                A100001A2000000000000001 /* AddTaskUseCase.swift */,
+                                B10000092000000000000001 /* AddTaskListUseCase.swift */,
+                                A100001C2000000000000001 /* UpdateTaskUseCase.swift */,
+                                D10000012000000000000001 /* UpdateTaskListUseCase.swift */,
+                                7669B43A71CB49D2B98BA1913776AD96 /* DeleteTaskUseCase.swift */,
+                                B100000B2000000000000001 /* DeleteTaskListUseCase.swift */,
 			);
 			path = usecases;
 			sourceTree = "<group>";
@@ -421,9 +424,10 @@
 				A10000172000000000000001 /* FetchTasksUseCase.swift in Sources */,
 				A10000192000000000000001 /* GetTaskByIDUseCase.swift in Sources */,
 				A100001B2000000000000001 /* AddTaskUseCase.swift in Sources */,
-				B100000A2000000000000001 /* AddTaskListUseCase.swift in Sources */,
-				A100001D2000000000000001 /* UpdateTaskStatusUseCase.swift in Sources */,
-				6F4251F89B1545F5A052964D1BA0481D /* DeleteTaskUseCase.swift in Sources */,
+                                B100000A2000000000000001 /* AddTaskListUseCase.swift in Sources */,
+                                A100001D2000000000000001 /* UpdateTaskUseCase.swift in Sources */,
+                                D10000022000000000000001 /* UpdateTaskListUseCase.swift in Sources */,
+                                6F4251F89B1545F5A052964D1BA0481D /* DeleteTaskUseCase.swift in Sources */,
 				B100000C2000000000000001 /* DeleteTaskListUseCase.swift in Sources */,
 				A100001F2000000000000001 /* TaskRepositoryImpl.swift in Sources */,
 				A10000252000000000000001 /* TaskDataModel.swift in Sources */,

--- a/TodoListApp/TodoListApp/Resources/Localizations/en.lproj/Localizable.strings
+++ b/TodoListApp/TodoListApp/Resources/Localizations/en.lproj/Localizable.strings
@@ -15,11 +15,13 @@
 "form_description_placeholder" = "Add more details";
 "form_due_date" = "Due date";
 "form_add_task" = "New task";
+"form_edit_task" = "Edit task";
 "form_list" = "List";
 "form_category" = "Category";
 "form_list_name" = "List name";
 "form_list_name_placeholder" = "Add a list name";
 "form_add_list" = "New list";
+"form_edit_list" = "Edit list";
 "action_cancel" = "Cancel";
 "action_save" = "Save";
 "icon_tasks" = "Tasks";
@@ -33,6 +35,7 @@
 "lists_title" = "Task lists";
 "action_add_list" = "Add list";
 "action_add_task" = "Add task";
+"action_edit" = "Edit";
 "action_delete" = "Delete";
 "action_delete_list" = "Delete list";
 "language_picker" = "Language";
@@ -45,6 +48,7 @@
 "error_unknown" = "Something went wrong. Please try again.";
 "action_accept" = "OK";
 "detail_title" = "Task";
+"detail_status_section" = "Status";
 "language_english" = "English";
 "language_spanish" = "Spanish";
 "category_work" = "Work";

--- a/TodoListApp/TodoListApp/Resources/Localizations/es.lproj/Localizable.strings
+++ b/TodoListApp/TodoListApp/Resources/Localizations/es.lproj/Localizable.strings
@@ -15,11 +15,13 @@
 "form_description_placeholder" = "Añade más detalles";
 "form_due_date" = "Fecha límite";
 "form_add_task" = "Nueva tarea";
+"form_edit_task" = "Editar tarea";
 "form_list" = "Lista";
 "form_category" = "Categoría";
 "form_list_name" = "Nombre de la lista";
 "form_list_name_placeholder" = "Añade un nombre de lista";
 "form_add_list" = "Nueva lista";
+"form_edit_list" = "Editar lista";
 "action_cancel" = "Cancelar";
 "action_save" = "Guardar";
 "icon_tasks" = "Tareas";
@@ -33,6 +35,7 @@
 "lists_title" = "Listas";
 "action_add_list" = "Agregar lista";
 "action_add_task" = "Agregar tarea";
+"action_edit" = "Editar";
 "action_delete" = "Eliminar";
 "action_delete_list" = "Eliminar lista";
 "language_picker" = "Idioma";
@@ -45,6 +48,7 @@
 "error_unknown" = "Algo salió mal. Inténtalo de nuevo.";
 "action_accept" = "Aceptar";
 "detail_title" = "Tarea";
+"detail_status_section" = "Estado";
 "language_english" = "Inglés";
 "language_spanish" = "Español";
 "category_work" = "Trabajo";

--- a/TodoListApp/TodoListApp/src/data/datasources/CoreDataTaskListDataSource.swift
+++ b/TodoListApp/TodoListApp/src/data/datasources/CoreDataTaskListDataSource.swift
@@ -29,6 +29,14 @@ public final class CoreDataTaskListDataSource {
         try context.save()
     }
 
+    public func update(list: TaskListDataModel) throws {
+        guard let entity = try fetchListEntity(identifier: list.identifier) else {
+            throw TaskDataSourceError.listNotFound
+        }
+        entity.update(from: list)
+        try context.save()
+    }
+
     public func deleteList(by identifier: UUID) throws {
         guard let entity = try fetchListEntity(identifier: identifier) else {
             throw TaskDataSourceError.listNotFound

--- a/TodoListApp/TodoListApp/src/data/repositories/TaskRepositoryImpl.swift
+++ b/TodoListApp/TodoListApp/src/data/repositories/TaskRepositoryImpl.swift
@@ -18,6 +18,11 @@ public final class TaskListRepositoryImpl: TaskListRepository {
         try dataSource.add(list: model)
     }
 
+    public func update(list: TaskList) throws {
+        let model = mapToData(list: list)
+        try dataSource.update(list: model)
+    }
+
     public func deleteList(identifier: UUID) throws {
         try dataSource.deleteList(by: identifier)
     }

--- a/TodoListApp/TodoListApp/src/domain/models/Task.swift
+++ b/TodoListApp/TodoListApp/src/domain/models/Task.swift
@@ -2,6 +2,8 @@ import Foundation
 
 /// Domain representation of a task.
 public struct Task: Identifiable, Equatable, Codable {
+    public static let defaultIconName = "checkmark.circle"
+
     public let id: UUID
     public var iconName: String
     public var title: String

--- a/TodoListApp/TodoListApp/src/domain/repositories/TaskRepository.swift
+++ b/TodoListApp/TodoListApp/src/domain/repositories/TaskRepository.swift
@@ -4,6 +4,7 @@ import Foundation
 public protocol TaskListRepository {
     func fetchLists() throws -> [TaskList]
     func add(list: TaskList) throws
+    func update(list: TaskList) throws
     func deleteList(identifier: UUID) throws
     func add(task: Task) throws
     func update(task: Task) throws

--- a/TodoListApp/TodoListApp/src/domain/usecases/UpdateTaskListUseCase.swift
+++ b/TodoListApp/TodoListApp/src/domain/usecases/UpdateTaskListUseCase.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Updates the metadata of an existing task list.
+public struct UpdateTaskListUseCase {
+    private let repository: TaskListRepository
+
+    public init(repository: TaskListRepository) {
+        self.repository = repository
+    }
+
+    public func execute(list: TaskList) throws {
+        try repository.update(list: list)
+    }
+}

--- a/TodoListApp/TodoListApp/src/domain/usecases/UpdateTaskUseCase.swift
+++ b/TodoListApp/TodoListApp/src/domain/usecases/UpdateTaskUseCase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Updates a task state inside the repository.
-public struct UpdateTaskStatusUseCase {
+/// Updates a task inside the repository.
+public struct UpdateTaskUseCase {
     private let repository: TaskListRepository
 
     public init(repository: TaskListRepository) {

--- a/TodoListApp/TodoListApp/src/presentation/navigation/TodoListAppApp.swift
+++ b/TodoListApp/TodoListApp/src/presentation/navigation/TodoListAppApp.swift
@@ -38,8 +38,9 @@ private final class AppDependencies {
             addTaskListUseCase: AddTaskListUseCase(repository: repository),
             deleteTaskListUseCase: DeleteTaskListUseCase(repository: repository),
             addTaskUseCase: AddTaskToListUseCase(repository: repository),
-            updateTaskStatusUseCase: UpdateTaskStatusUseCase(repository: repository),
-            deleteTaskUseCase: DeleteTaskUseCase(repository: repository)
+            updateTaskUseCase: UpdateTaskUseCase(repository: repository),
+            deleteTaskUseCase: DeleteTaskUseCase(repository: repository),
+            updateTaskListUseCase: UpdateTaskListUseCase(repository: repository)
         )
     }
 
@@ -47,7 +48,7 @@ private final class AppDependencies {
         TaskDetailViewModel(
             taskIdentifier: identifier,
             getTaskByIDUseCase: GetTaskByIDUseCase(repository: repository),
-            updateTaskStatusUseCase: UpdateTaskStatusUseCase(repository: repository)
+            updateTaskUseCase: UpdateTaskUseCase(repository: repository)
         )
     }
 }

--- a/TodoListApp/TodoListApp/src/presentation/viewmodels/TaskDetailViewModel.swift
+++ b/TodoListApp/TodoListApp/src/presentation/viewmodels/TaskDetailViewModel.swift
@@ -7,16 +7,16 @@ public final class TaskDetailViewModel: ObservableObject {
 
     private let taskIdentifier: UUID
     private let getTaskByIDUseCase: GetTaskByIDUseCase
-    private let updateTaskStatusUseCase: UpdateTaskStatusUseCase
+    private let updateTaskUseCase: UpdateTaskUseCase
 
     public init(
         taskIdentifier: UUID,
         getTaskByIDUseCase: GetTaskByIDUseCase,
-        updateTaskStatusUseCase: UpdateTaskStatusUseCase
+        updateTaskUseCase: UpdateTaskUseCase
     ) {
         self.taskIdentifier = taskIdentifier
         self.getTaskByIDUseCase = getTaskByIDUseCase
-        self.updateTaskStatusUseCase = updateTaskStatusUseCase
+        self.updateTaskUseCase = updateTaskUseCase
     }
 
     @MainActor
@@ -33,7 +33,7 @@ public final class TaskDetailViewModel: ObservableObject {
         guard var currentTask = task else { return }
         currentTask.status = currentTask.status == .completed ? .pending : .completed
         do {
-            try updateTaskStatusUseCase.execute(task: currentTask)
+            try updateTaskUseCase.execute(task: currentTask)
             loadTask()
         } catch {
             errorMessage = message(for: error)

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskListFormView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskListFormView.swift
@@ -8,6 +8,20 @@ struct TaskListFormView: View {
 
     let categories: [TaskCategory]
     let onSave: (String, TaskCategory) -> Void
+    private let isEditing: Bool
+
+    init(
+        categories: [TaskCategory],
+        initialList: TaskList? = nil,
+        onSave: @escaping (String, TaskCategory) -> Void
+    ) {
+        self.categories = categories
+        self.onSave = onSave
+        self.isEditing = initialList != nil
+        _name = State(initialValue: initialList?.name ?? "")
+        let defaultCategory = initialList?.category ?? categories.first ?? .work
+        _selectedCategory = State(initialValue: defaultCategory)
+    }
 
     var body: some View {
         NavigationView {
@@ -29,7 +43,7 @@ struct TaskListFormView: View {
                     .pickerStyle(.inline)
                 }
             }
-            .navigationTitle(Text("form_add_list"))
+            .navigationTitle(Text(isEditing ? "form_edit_list" : "form_add_list"))
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("action_cancel") {
@@ -47,9 +61,6 @@ struct TaskListFormView: View {
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
-        .onAppear {
-            selectedCategory = categories.first ?? .work
-        }
     }
 }
 

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskRowView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskRowView.swift
@@ -10,42 +10,66 @@ struct TaskRowView: View {
     }()
 
     var body: some View {
-        HStack(spacing: 16) {
-            Image(systemName: task.iconName)
-                .font(.system(size: 28))
-                .foregroundColor(task.status == .completed ? .green : .accentColor)
-                .accessibilityHidden(true)
-
-            VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
                 Text(task.title)
                     .font(.headline)
+                    .multilineTextAlignment(.leading)
 
-                Text(task.listName)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+                Spacer()
 
-                HStack(spacing: 8) {
-                    Label {
-                        Text(LocalizedStringKey(task.category.localizationKey))
-                    } icon: {
-                        Image(systemName: task.category.iconName)
-                    }
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
+                Label {
                     Text(dateFormatter.string(from: task.dueDate))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                } icon: {
+                    Image(systemName: "calendar")
                 }
+                .font(.caption)
+                .foregroundColor(.secondary)
             }
 
-            Spacer()
+            if !task.details.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text(task.details)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+            }
 
-            Image(systemName: task.status == .completed ? "checkmark.circle.fill" : "clock")
-                .foregroundColor(task.status == .completed ? .green : .orange)
-                .accessibilityLabel(Text(task.status.localizationKey))
+            HStack(spacing: 12) {
+                Label {
+                    Text(task.listName)
+                } icon: {
+                    Image(systemName: "folder")
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+                Label {
+                    Text(LocalizedStringKey(task.category.localizationKey))
+                } icon: {
+                    Image(systemName: task.category.iconName)
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+                Spacer()
+
+                Text(task.status.localizationKey)
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(task.status == .completed ? Color.green.opacity(0.15) : Color.orange.opacity(0.15))
+                    .foregroundColor(task.status == .completed ? .green : .orange)
+                    .clipShape(Capsule())
+                    .accessibilityLabel(Text(task.status.localizationKey))
+            }
         }
-        .padding(.vertical, 8)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 }
 

--- a/TodoListApp/TodoListAppTests/TaskDetailViewModelTests.swift
+++ b/TodoListApp/TodoListAppTests/TaskDetailViewModelTests.swift
@@ -25,7 +25,7 @@ final class TaskDetailViewModelTests: XCTestCase {
         viewModel = TaskDetailViewModel(
             taskIdentifier: task.id,
             getTaskByIDUseCase: GetTaskByIDUseCase(repository: repository),
-            updateTaskStatusUseCase: UpdateTaskStatusUseCase(repository: repository)
+            updateTaskUseCase: UpdateTaskUseCase(repository: repository)
         )
     }
 

--- a/TodoListApp/TodoListAppTests/TaskListRepositoryTests.swift
+++ b/TodoListApp/TodoListAppTests/TaskListRepositoryTests.swift
@@ -26,6 +26,20 @@ final class TaskListRepositoryTests: XCTestCase {
         XCTAssertTrue(lists.contains(where: { $0.id == list.id }))
     }
 
+    func testUpdateListPersistsChanges() throws {
+        var list = TaskList(name: "Errands", category: .errands)
+        try repository.add(list: list)
+
+        list.name = "Updated"
+        list.category = .work
+
+        try repository.update(list: list)
+
+        let storedList = try repository.fetchLists().first { $0.id == list.id }
+        XCTAssertEqual(storedList?.name, "Updated")
+        XCTAssertEqual(storedList?.category, .work)
+    }
+
     func testAddTaskToList() throws {
         let list = TaskList(name: "Personal", category: .personal)
         try repository.add(list: list)

--- a/TodoListApp/TodoListAppTests/TaskListViewModelTests.swift
+++ b/TodoListApp/TodoListAppTests/TaskListViewModelTests.swift
@@ -14,8 +14,9 @@ final class TaskListViewModelTests: XCTestCase {
             addTaskListUseCase: AddTaskListUseCase(repository: repository),
             deleteTaskListUseCase: DeleteTaskListUseCase(repository: repository),
             addTaskUseCase: AddTaskToListUseCase(repository: repository),
-            updateTaskStatusUseCase: UpdateTaskStatusUseCase(repository: repository),
-            deleteTaskUseCase: DeleteTaskUseCase(repository: repository)
+            updateTaskUseCase: UpdateTaskUseCase(repository: repository),
+            deleteTaskUseCase: DeleteTaskUseCase(repository: repository),
+            updateTaskListUseCase: UpdateTaskListUseCase(repository: repository)
         )
     }
 
@@ -96,5 +97,62 @@ final class TaskListViewModelTests: XCTestCase {
         viewModel.toggleStatus(for: storedTask)
 
         XCTAssertEqual(viewModel.lists.first?.tasks.first?.status, .completed)
+    }
+
+    func testUpdateTaskModifiesTaskInformation() throws {
+        var task = Task(
+            iconName: "bell",
+            title: "Reminder",
+            details: "Call a friend",
+            dueDate: Date(),
+            status: .pending,
+            listID: UUID(),
+            listName: "Personal",
+            category: .personal
+        )
+        repository.lists = [TaskList(id: task.listID, name: task.listName, category: .personal, tasks: [task])]
+        viewModel.loadLists()
+
+        guard let storedTask = viewModel.lists.first?.tasks.first else {
+            return XCTFail("Expected a task to be loaded")
+        }
+
+        let updatedTitle = "Updated"
+        let updatedDetails = "Call two friends"
+        let updatedDate = Date().addingTimeInterval(3600)
+        let updatedCategory: TaskCategory = .work
+
+        viewModel.updateTask(
+            storedTask,
+            title: updatedTitle,
+            details: updatedDetails,
+            dueDate: updatedDate,
+            category: updatedCategory
+        )
+
+        let reloadedTask = viewModel.lists.first?.tasks.first
+        XCTAssertEqual(reloadedTask?.title, updatedTitle)
+        XCTAssertEqual(reloadedTask?.details, updatedDetails)
+        XCTAssertEqual(reloadedTask?.category, updatedCategory)
+        if let reloadedDate = reloadedTask?.dueDate.timeIntervalSinceReferenceDate {
+            XCTAssertEqual(reloadedDate, updatedDate.timeIntervalSinceReferenceDate, accuracy: 0.5)
+        } else {
+            XCTFail("Expected a task date to be available")
+        }
+    }
+
+    func testUpdateListChangesNameAndCategory() throws {
+        let list = TaskList(name: "Personal", category: .personal)
+        repository.lists = [list]
+        viewModel.loadLists()
+
+        guard let storedList = viewModel.lists.first else {
+            return XCTFail("Expected a list to be loaded")
+        }
+
+        viewModel.update(list: storedList, name: "Updated", category: .work)
+
+        XCTAssertEqual(viewModel.lists.first?.name, "Updated")
+        XCTAssertEqual(viewModel.lists.first?.category, .work)
     }
 }

--- a/TodoListApp/TodoListAppTests/TaskUseCasesTests.swift
+++ b/TodoListApp/TodoListAppTests/TaskUseCasesTests.swift
@@ -65,7 +65,7 @@ final class TaskUseCasesTests: XCTestCase {
         XCTAssertEqual(repository.lists.first?.tasks, list.tasks)
     }
 
-    func testUpdateTaskStatusUseCaseUpdatesTask() throws {
+    func testUpdateTaskUseCaseUpdatesTask() throws {
         var task = Task(
             iconName: "star",
             title: "Focus",
@@ -78,13 +78,27 @@ final class TaskUseCasesTests: XCTestCase {
         )
         var list = TaskList(id: task.listID, name: task.listName, category: .work, tasks: [task])
         repository.lists = [list]
-        let useCase = UpdateTaskStatusUseCase(repository: repository)
+        let useCase = UpdateTaskUseCase(repository: repository)
 
         task.status = .completed
         try useCase.execute(task: task)
 
         list.tasks[0] = task
         XCTAssertEqual(repository.lists.first?.tasks, list.tasks)
+    }
+
+    func testUpdateTaskListUseCaseUpdatesList() throws {
+        var list = TaskList(name: "Personal", category: .personal)
+        repository.lists = [list]
+        let useCase = UpdateTaskListUseCase(repository: repository)
+
+        list.name = "Updated"
+        list.category = .work
+
+        try useCase.execute(list: list)
+
+        XCTAssertEqual(repository.lists.first?.name, "Updated")
+        XCTAssertEqual(repository.lists.first?.category, .work)
     }
 
     func testDeleteTaskUseCaseRemovesTask() throws {

--- a/TodoListApp/TodoListAppTests/TestDoubles/TaskListRepositoryMock.swift
+++ b/TodoListApp/TodoListAppTests/TestDoubles/TaskListRepositoryMock.swift
@@ -5,6 +5,7 @@ final class TaskListRepositoryMock: TaskListRepository {
     var lists: [TaskList] = []
     var fetchListsError: Error?
     var addListError: Error?
+    var updateListError: Error?
     var deleteListError: Error?
     var addTaskError: Error?
     var updateTaskError: Error?
@@ -23,6 +24,16 @@ final class TaskListRepositoryMock: TaskListRepository {
             throw error
         }
         lists.append(list)
+    }
+
+    func update(list: TaskList) throws {
+        if let error = updateListError {
+            throw error
+        }
+        guard let index = lists.firstIndex(where: { $0.id == list.id }) else {
+            throw TaskDataSourceError.listNotFound
+        }
+        lists[index] = list
     }
 
     func deleteList(identifier: UUID) throws {


### PR DESCRIPTION
## Summary
- allow tasks and lists to be edited via reusable form sheets and new update use cases
- refresh task row and detail layouts to remove the leading icon and better organize task information
- extend repository/update infrastructure and add unit tests covering the new editing flows

## Testing
- not run (xcodebuild unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68debf9b7e4883299873149646940c7b