### PR TITLE
Add comprehensive tests and refresh minimal task UI

### DIFF
--- a/TodoListApp/TodoListApp.xcodeproj/project.pbxproj
+++ b/TodoListApp/TodoListApp.xcodeproj/project.pbxproj
@@ -12,7 +12,11 @@
 		665E967E2E8EF04A004CAAD7 /* TaskUseCasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665E96702E8EF035004CAAD7 /* TaskUseCasesTests.swift */; };
 		665E967F2E8EF04E004CAAD7 /* TaskListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665E96742E8EF035004CAAD7 /* TaskListViewModelTests.swift */; };
 		665E96802E8EF051004CAAD7 /* TaskListRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665E96732E8EF035004CAAD7 /* TaskListRepositoryTests.swift */; };
-		665E96812E8EF055004CAAD7 /* TaskListRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665E96722E8EF035004CAAD7 /* TaskListRepositoryMock.swift */; };
+                665E96812E8EF055004CAAD7 /* TaskListRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665E96722E8EF035004CAAD7 /* TaskListRepositoryMock.swift */; };
+                D1C1A0022F6A4E7B00AAA111 /* CoreDataTaskListDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C1A0012F6A4E7B00AAA111 /* CoreDataTaskListDataSourceTests.swift */; };
+                D1C1A0042F6A4E7B00AAA111 /* LanguageControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C1A0032F6A4E7B00AAA111 /* LanguageControllerTests.swift */; };
+                D1C1A0062F6A4E7B00AAA111 /* TaskDataSourceErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C1A0052F6A4E7B00AAA111 /* TaskDataSourceErrorTests.swift */; };
+                D1C1A0082F6A4E7B00AAA111 /* TaskDomainModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C1A0072F6A4E7B00AAA111 /* TaskDomainModelTests.swift */; };
 		6F4251F89B1545F5A052964D1BA0481D /* DeleteTaskUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7669B43A71CB49D2B98BA1913776AD96 /* DeleteTaskUseCase.swift */; };
 		A10000012000000000000001 /* TaskListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000002000000000000001 /* TaskListView.swift */; };
 		A10000032000000000000001 /* TaskDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000022000000000000001 /* TaskDetailView.swift */; };
@@ -60,8 +64,12 @@
 		665E966F2E8EF035004CAAD7 /* TaskDetailViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskDetailViewModelTests.swift; sourceTree = "<group>"; };
 		665E96702E8EF035004CAAD7 /* TaskUseCasesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskUseCasesTests.swift; sourceTree = "<group>"; };
 		665E96722E8EF035004CAAD7 /* TaskListRepositoryMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskListRepositoryMock.swift; sourceTree = "<group>"; };
-		665E96732E8EF035004CAAD7 /* TaskListRepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskListRepositoryTests.swift; sourceTree = "<group>"; };
-		665E96742E8EF035004CAAD7 /* TaskListViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskListViewModelTests.swift; sourceTree = "<group>"; };
+                665E96732E8EF035004CAAD7 /* TaskListRepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskListRepositoryTests.swift; sourceTree = "<group>"; };
+                665E96742E8EF035004CAAD7 /* TaskListViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskListViewModelTests.swift; sourceTree = "<group>"; };
+                D1C1A0012F6A4E7B00AAA111 /* CoreDataTaskListDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTaskListDataSourceTests.swift; sourceTree = "<group>"; };
+                D1C1A0032F6A4E7B00AAA111 /* LanguageControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageControllerTests.swift; sourceTree = "<group>"; };
+                D1C1A0052F6A4E7B00AAA111 /* TaskDataSourceErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDataSourceErrorTests.swift; sourceTree = "<group>"; };
+                D1C1A0072F6A4E7B00AAA111 /* TaskDomainModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDomainModelTests.swift; sourceTree = "<group>"; };
 		7669B43A71CB49D2B98BA1913776AD96 /* DeleteTaskUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteTaskUseCase.swift; sourceTree = "<group>"; };
 		A10000002000000000000001 /* TaskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListView.swift; sourceTree = "<group>"; };
 		A10000022000000000000001 /* TaskDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailView.swift; sourceTree = "<group>"; };
@@ -137,27 +145,31 @@
 			path = TestDoubles;
 			sourceTree = "<group>";
 		};
-		665E96752E8EF035004CAAD7 /* Data */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Data;
-			sourceTree = "<group>";
-		};
-		665E96762E8EF035004CAAD7 /* Domain */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Domain;
-			sourceTree = "<group>";
-		};
-		665E96772E8EF035004CAAD7 /* Presentation */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Presentation;
-			sourceTree = "<group>";
-		};
+                665E96752E8EF035004CAAD7 /* Data */ = {
+                        isa = PBXGroup;
+                        children = (
+                                D1C1A0012F6A4E7B00AAA111 /* CoreDataTaskListDataSourceTests.swift */,
+                                D1C1A0052F6A4E7B00AAA111 /* TaskDataSourceErrorTests.swift */,
+                        );
+                        path = Data;
+                        sourceTree = "<group>";
+                };
+                665E96762E8EF035004CAAD7 /* Domain */ = {
+                        isa = PBXGroup;
+                        children = (
+                                D1C1A0072F6A4E7B00AAA111 /* TaskDomainModelTests.swift */,
+                        );
+                        path = Domain;
+                        sourceTree = "<group>";
+                };
+                665E96772E8EF035004CAAD7 /* Presentation */ = {
+                        isa = PBXGroup;
+                        children = (
+                                D1C1A0032F6A4E7B00AAA111 /* LanguageControllerTests.swift */,
+                        );
+                        path = Presentation;
+                        sourceTree = "<group>";
+                };
 		A10000402000000000000001 = {
 			isa = PBXGroup;
 			children = (
@@ -438,13 +450,17 @@
 		B10000122000000000000001 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				665E967F2E8EF04E004CAAD7 /* TaskListViewModelTests.swift in Sources */,
-				665E967E2E8EF04A004CAAD7 /* TaskUseCasesTests.swift in Sources */,
-				665E96812E8EF055004CAAD7 /* TaskListRepositoryMock.swift in Sources */,
-				665E96802E8EF051004CAAD7 /* TaskListRepositoryTests.swift in Sources */,
-				665E967D2E8EF047004CAAD7 /* TaskDetailViewModelTests.swift in Sources */,
-			);
+                        files = (
+                                665E967F2E8EF04E004CAAD7 /* TaskListViewModelTests.swift in Sources */,
+                                665E967E2E8EF04A004CAAD7 /* TaskUseCasesTests.swift in Sources */,
+                                665E96812E8EF055004CAAD7 /* TaskListRepositoryMock.swift in Sources */,
+                                665E96802E8EF051004CAAD7 /* TaskListRepositoryTests.swift in Sources */,
+                                665E967D2E8EF047004CAAD7 /* TaskDetailViewModelTests.swift in Sources */,
+                                D1C1A0022F6A4E7B00AAA111 /* CoreDataTaskListDataSourceTests.swift in Sources */,
+                                D1C1A0042F6A4E7B00AAA111 /* LanguageControllerTests.swift in Sources */,
+                                D1C1A0062F6A4E7B00AAA111 /* TaskDataSourceErrorTests.swift in Sources */,
+                                D1C1A0082F6A4E7B00AAA111 /* TaskDomainModelTests.swift in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */

--- a/TodoListApp/TodoListApp/Resources/Localizations/en.lproj/Localizable.strings
+++ b/TodoListApp/TodoListApp/Resources/Localizations/en.lproj/Localizable.strings
@@ -35,6 +35,9 @@
 "action_add_task" = "Add task";
 "action_delete" = "Delete";
 "action_delete_list" = "Delete list";
+"task_row_description_label" = "Description";
+"task_row_date_label" = "Date";
+"task_row_category_label" = "Category";
 "language_picker" = "Language";
 "language_menu" = "Language";
 "action_mark_pending" = "Mark as pending";

--- a/TodoListApp/TodoListApp/Resources/Localizations/es.lproj/Localizable.strings
+++ b/TodoListApp/TodoListApp/Resources/Localizations/es.lproj/Localizable.strings
@@ -35,6 +35,9 @@
 "action_add_task" = "Agregar tarea";
 "action_delete" = "Eliminar";
 "action_delete_list" = "Eliminar lista";
+"task_row_description_label" = "Descripción";
+"task_row_date_label" = "Fecha";
+"task_row_category_label" = "Categoría";
 "language_picker" = "Idioma";
 "language_menu" = "Idioma";
 "action_mark_pending" = "Marcar como pendiente";

--- a/TodoListApp/TodoListApp/src/presentation/viewmodels/TaskListViewModel.swift
+++ b/TodoListApp/TodoListApp/src/presentation/viewmodels/TaskListViewModel.swift
@@ -80,14 +80,13 @@ public final class TaskListViewModel: ObservableObject {
     @MainActor
     public func addTask(
         to list: TaskList,
-        iconName: String,
         title: String,
         details: String,
         dueDate: Date,
         category: TaskCategory
     ) {
         let task = Task(
-            iconName: iconName,
+            iconName: category.iconName,
             title: title,
             details: details,
             dueDate: dueDate,

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskDetailView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskDetailView.swift
@@ -18,80 +18,73 @@ struct TaskDetailView: View {
         Group {
             if let task = viewModel.task {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 16) {
-                        HStack(spacing: 16) {
-                            Image(systemName: task.iconName)
-                                .font(.system(size: 50))
-                                .foregroundColor(.accentColor)
-                                .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 24) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text(task.title)
+                                .font(.title2)
+                                .fontWeight(.semibold)
 
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text(task.title)
-                                    .font(.title)
-                                    .bold()
-                                Label {
-                                    Text(dateFormatter.string(from: task.dueDate))
-                                } icon: {
-                                    Image(systemName: "calendar")
-                                }
+                            Text(dateFormatter.string(from: task.dueDate))
+                                .font(.subheadline)
                                 .foregroundColor(.secondary)
-                            }
+
+                            Text(task.details)
+                                .font(.body)
+                                .foregroundColor(.primary)
                         }
+                        .padding(20)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                                .fill(Color(.secondarySystemBackground))
+                        )
 
-                        VStack(alignment: .leading, spacing: 8) {
-                            Label {
-                                Text(task.listName)
-                            } icon: {
-                                Image(systemName: "folder")
-                            }
-                            .font(.headline)
-
-                            Label {
-                                Text(LocalizedStringKey(task.category.localizationKey))
-                            } icon: {
-                                Image(systemName: task.category.iconName)
-                            }
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
+                        VStack(alignment: .leading, spacing: 16) {
+                            infoRow(title: "form_list", value: Text(task.listName))
+                            infoRow(title: "form_category", value: Text(LocalizedStringKey(task.category.localizationKey)))
                         }
+                        .padding(20)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                                .fill(Color(.secondarySystemBackground))
+                        )
 
-                        Text(task.details)
-                            .font(.body)
-
-                        Divider()
-
-                        HStack {
-                            Label(
-                                title: { Text(task.status.localizationKey) },
-                                icon: {
-                                    Image(systemName: task.status == .completed ? "checkmark.circle.fill" : "clock")
-                                }
-                            )
-                            .font(.headline)
-                            .foregroundColor(task.status == .completed ? .green : .orange)
-
-                            Spacer()
+                        VStack(alignment: .leading, spacing: 16) {
+                            Text(task.status.localizationKey)
+                                .font(.headline)
+                                .foregroundColor(task.status == .completed ? .green : .orange)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background((task.status == .completed ? Color.green : Color.orange).opacity(0.15))
+                                .clipShape(Capsule())
 
                             Button(action: {
                                 viewModel.toggleStatus()
                             }) {
                                 Text(task.status == .completed ? "action_mark_pending" : "action_mark_completed")
                                     .font(.headline)
-                                    .padding(.horizontal, 16)
-                                    .padding(.vertical, 8)
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 12)
                                     .background(Color.accentColor)
                                     .foregroundColor(.white)
-                                    .cornerRadius(8)
+                                    .cornerRadius(12)
                             }
+                            .buttonStyle(PlainButtonStyle())
                         }
+                        .padding(20)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                                .fill(Color(.secondarySystemBackground))
+                        )
                     }
-                    .padding()
+                    .padding(.horizontal)
+                    .padding(.vertical, 24)
                 }
+                .background(Color(.systemGroupedBackground).ignoresSafeArea())
             } else if let error = viewModel.errorMessage {
                 VStack(spacing: 12) {
-                    Image(systemName: "exclamationmark.triangle")
-                        .font(.system(size: 40))
-                        .foregroundColor(.orange)
                     Text("error_title")
                         .font(.headline)
                     Text(error)
@@ -108,6 +101,17 @@ struct TaskDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             viewModel.loadTask()
+        }
+    }
+
+    private func infoRow(title: LocalizedStringKey, value: Text) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            value
+                .font(.headline)
+                .foregroundColor(.primary)
         }
     }
 }
@@ -139,5 +143,6 @@ struct TaskDetailView_Previews: PreviewProvider {
                 )
             )
         }
+        .background(Color(.systemGroupedBackground))
     }
 }

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskDetailView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskDetailView.swift
@@ -18,24 +18,32 @@ struct TaskDetailView: View {
         Group {
             if let task = viewModel.task {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 24) {
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text(task.title)
-                                .font(.title2)
-                                .fontWeight(.semibold)
+                    VStack(alignment: .leading, spacing: 28) {
+                        VStack(alignment: .leading, spacing: 18) {
+                            labeledContent(title: "Titulo") {
+                                Text(task.title)
+                                    .font(.title2)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.primary)
+                            }
 
-                            Text(dateFormatter.string(from: task.dueDate))
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
+                            labeledContent(title: "Fecha") {
+                                Text(dateFormatter.string(from: task.dueDate))
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
 
-                            Text(task.details)
-                                .font(.body)
-                                .foregroundColor(.primary)
+                            labeledContent(title: "Descripcion") {
+                                Text(task.details)
+                                    .font(.body)
+                                    .foregroundColor(.primary)
+                            }
                         }
-                        .padding(20)
+                        .padding(.vertical, 28)
+                        .padding(.horizontal, 24)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(
-                            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            RoundedRectangle(cornerRadius: 24, style: .continuous)
                                 .fill(Color(.secondarySystemBackground))
                         )
 
@@ -43,10 +51,11 @@ struct TaskDetailView: View {
                             infoRow(title: "form_list", value: Text(task.listName))
                             infoRow(title: "form_category", value: Text(LocalizedStringKey(task.category.localizationKey)))
                         }
-                        .padding(20)
+                        .padding(.vertical, 24)
+                        .padding(.horizontal, 24)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(
-                            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            RoundedRectangle(cornerRadius: 24, style: .continuous)
                                 .fill(Color(.secondarySystemBackground))
                         )
 
@@ -72,15 +81,16 @@ struct TaskDetailView: View {
                             }
                             .buttonStyle(PlainButtonStyle())
                         }
-                        .padding(20)
+                        .padding(.vertical, 24)
+                        .padding(.horizontal, 24)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(
-                            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            RoundedRectangle(cornerRadius: 24, style: .continuous)
                                 .fill(Color(.secondarySystemBackground))
                         )
                     }
-                    .padding(.horizontal)
-                    .padding(.vertical, 24)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 32)
                 }
                 .background(Color(.systemGroupedBackground).ignoresSafeArea())
             } else if let error = viewModel.errorMessage {
@@ -112,6 +122,16 @@ struct TaskDetailView: View {
             value
                 .font(.headline)
                 .foregroundColor(.primary)
+        }
+    }
+
+    private func labeledContent<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .textCase(nil)
+            content()
         }
     }
 }

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskFormView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskFormView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct TaskFormView: View {
     @Environment(\.presentationMode) private var presentationMode
 
-    @State private var iconName: String = "list.bullet.circle"
     @State private var title: String = ""
     @State private var details: String = ""
     @State private var dueDate: Date = Date()
@@ -11,16 +10,7 @@ struct TaskFormView: View {
 
     let listName: String
     let categories: [TaskCategory]
-    let onSave: (String, String, String, Date, TaskCategory) -> Void
-
-    private let availableIcons: [String] = [
-        "list.bullet.circle",
-        "list.bullet.clipboard",
-        "tray.full",
-        "calendar",
-        "star",
-        "bell"
-    ]
+    let onSave: (String, String, Date, TaskCategory) -> Void
 
     var body: some View {
         NavigationView {
@@ -28,15 +18,6 @@ struct TaskFormView: View {
                 Section(header: Text("form_list")) {
                     Text(listName)
                         .foregroundColor(.primary)
-                }
-
-                Section(header: Text("form_icon")) {
-                    Picker("form_icon", selection: $iconName) {
-                        ForEach(availableIcons, id: \.self) { icon in
-                            Text(iconTitle(for: icon))
-                                .tag(icon)
-                        }
-                    }
                 }
 
                 Section(header: Text("form_category")) {
@@ -86,7 +67,7 @@ struct TaskFormView: View {
 
                 ToolbarItem(placement: .confirmationAction) {
                     Button("action_save") {
-                        onSave(iconName, title, details, dueDate, selectedCategory)
+                        onSave(title, details, dueDate, selectedCategory)
                         presentationMode.wrappedValue.dismiss()
                     }
                     .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -100,24 +81,6 @@ struct TaskFormView: View {
         }
     }
 
-    private func iconTitle(for icon: String) -> String {
-        switch icon {
-        case "list.bullet.circle":
-            return NSLocalizedString("icon_tasks", comment: "")
-        case "list.bullet.clipboard":
-            return NSLocalizedString("icon_clipboard", comment: "")
-        case "tray.full":
-            return NSLocalizedString("icon_inbox", comment: "")
-        case "calendar":
-            return NSLocalizedString("icon_calendar", comment: "")
-        case "star":
-            return NSLocalizedString("icon_star", comment: "")
-        case "bell":
-            return NSLocalizedString("icon_bell", comment: "")
-        default:
-            return icon
-        }
-    }
 }
 
 struct TaskFormView_Previews: PreviewProvider {
@@ -125,6 +88,6 @@ struct TaskFormView_Previews: PreviewProvider {
         TaskFormView(
             listName: NSLocalizedString("sample_list_work", comment: ""),
             categories: TaskCategory.allCases
-        ) { _, _, _, _, _ in }
+        ) { _, _, _, _ in }
     }
 }

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskFormView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskFormView.swift
@@ -26,18 +26,15 @@ struct TaskFormView: View {
         NavigationView {
             Form {
                 Section(header: Text("form_list")) {
-                    Label(listName, systemImage: "folder")
+                    Text(listName)
                         .foregroundColor(.primary)
                 }
 
                 Section(header: Text("form_icon")) {
                     Picker("form_icon", selection: $iconName) {
                         ForEach(availableIcons, id: \.self) { icon in
-                            Label(
-                                title: { Text(iconTitle(for: icon)) },
-                                icon: { Image(systemName: icon) }
-                            )
-                            .tag(icon)
+                            Text(iconTitle(for: icon))
+                                .tag(icon)
                         }
                     }
                 }
@@ -45,11 +42,8 @@ struct TaskFormView: View {
                 Section(header: Text("form_category")) {
                     Picker("form_category", selection: $selectedCategory) {
                         ForEach(categories) { category in
-                            Label(
-                                title: { Text(LocalizedStringKey(category.localizationKey)) },
-                                icon: { Image(systemName: category.iconName) }
-                            )
-                            .tag(category)
+                            Text(LocalizedStringKey(category.localizationKey))
+                                .tag(category)
                         }
                     }
                     .pickerStyle(.inline)
@@ -98,6 +92,7 @@ struct TaskFormView: View {
                     .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
+            .navigationBarTitleDisplayMode(.inline)
         }
         .navigationViewStyle(StackNavigationViewStyle())
         .onAppear {

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskListFormView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskListFormView.swift
@@ -19,17 +19,15 @@ struct TaskListFormView: View {
                 Section(header: Text("form_category")) {
                     Picker("form_category", selection: $selectedCategory) {
                         ForEach(categories) { category in
-                            Label(
-                                title: { Text(LocalizedStringKey(category.localizationKey)) },
-                                icon: { Image(systemName: category.iconName) }
-                            )
-                            .tag(category)
+                            Text(LocalizedStringKey(category.localizationKey))
+                                .tag(category)
                         }
                     }
                     .pickerStyle(.inline)
                 }
             }
             .navigationTitle(Text("form_add_list"))
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("action_cancel") {

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskListView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskListView.swift
@@ -48,7 +48,7 @@ struct TaskListView: View {
                                             .padding(.vertical, 10)
                                             .padding(.horizontal, 16)
                                     }
-                                    .listRowInsets(EdgeInsets())
+                                    .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 16))
                                     .listRowBackground(Color.clear)
                                     .contextMenu {
                                         Button(action: {
@@ -132,10 +132,9 @@ struct TaskListView: View {
                     TaskFormView(
                         listName: list.name,
                         categories: categories
-                    ) { icon, title, details, date, category in
+                    ) { title, details, date, category in
                         viewModel.addTask(
                             to: list,
-                            iconName: icon,
                             title: title,
                             details: details,
                             dueDate: date,

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskListView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskListView.swift
@@ -45,7 +45,8 @@ struct TaskListView: View {
                                         detailBuilder(task)
                                     } label: {
                                         TaskRowView(task: task)
-                                            .padding(.vertical, 6)
+                                            .padding(.vertical, 10)
+                                            .padding(.horizontal, 16)
                                     }
                                     .listRowInsets(EdgeInsets())
                                     .listRowBackground(Color.clear)
@@ -81,7 +82,12 @@ struct TaskListView: View {
                                     }
                                     .font(.subheadline)
                                     .foregroundColor(.accentColor)
-                                    .padding(.vertical, 4)
+                                    .padding(.vertical, 8)
+                                    .padding(.horizontal, 16)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                            .fill(Color(.secondarySystemBackground))
+                                    )
                                 }
                                 .listRowInsets(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
                                 .listRowBackground(Color.clear)

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskListView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskListView.swift
@@ -26,12 +26,10 @@ struct TaskListView: View {
         NavigationView {
             Group {
                 if viewModel.lists.isEmpty {
-                    VStack(spacing: 16) {
-                        Image(systemName: "list.bullet.rectangle")
-                            .font(.system(size: 48))
-                            .foregroundColor(.accentColor)
+                    VStack(spacing: 12) {
                         Text("empty_lists_title")
-                            .font(.headline)
+                            .font(.title3)
+                            .fontWeight(.semibold)
                         Text("empty_lists_description")
                             .font(.subheadline)
                             .foregroundColor(.secondary)
@@ -41,28 +39,31 @@ struct TaskListView: View {
                 } else {
                     List {
                         ForEach(Array(viewModel.lists.enumerated()), id: \.element.id) { _, list in
-                            Section {
+                            Section(header: header(for: list)) {
                                 ForEach(list.tasks) { task in
                                     NavigationLink {
                                         detailBuilder(task)
                                     } label: {
                                         TaskRowView(task: task)
-                                            .contextMenu {
-                                                Button(action: {
-                                                    viewModel.toggleStatus(for: task)
-                                                }) {
-                                                    Label(
-                                                        task.status == .completed ? "action_mark_pending" : "action_mark_completed",
-                                                        systemImage: task.status == .completed ? "arrow.uturn.left" : "checkmark"
-                                                    )
-                                                }
+                                            .padding(.vertical, 6)
+                                    }
+                                    .listRowInsets(EdgeInsets())
+                                    .listRowBackground(Color.clear)
+                                    .contextMenu {
+                                        Button(action: {
+                                            viewModel.toggleStatus(for: task)
+                                        }) {
+                                            Label(
+                                                task.status == .completed ? "action_mark_pending" : "action_mark_completed",
+                                                systemImage: task.status == .completed ? "arrow.uturn.left" : "checkmark"
+                                            )
+                                        }
 
-                                                Button(role: .destructive, action: {
-                                                    viewModel.deleteTask(task)
-                                                }) {
-                                                    Label("action_delete", systemImage: "trash")
-                                                }
-                                            }
+                                        Button(role: .destructive, action: {
+                                            viewModel.deleteTask(task)
+                                        }) {
+                                            Label("action_delete", systemImage: "trash")
+                                        }
                                     }
                                 }
                                 .onDelete { offsets in
@@ -73,39 +74,25 @@ struct TaskListView: View {
                                     selectedListForTask = list
                                     isPresentingTaskForm = true
                                 } label: {
-                                    Label("action_add_task", systemImage: "plus.circle")
-                                }
-                            } header: {
-                                HStack(spacing: 8) {
-                                    Image(systemName: list.category.iconName)
-                                        .foregroundColor(.accentColor)
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        Text(list.name)
-                                            .font(.headline)
-                                        Text(LocalizedStringKey(list.category.localizationKey))
-                                            .font(.subheadline)
-                                            .foregroundColor(.secondary)
+                                    HStack {
+                                        Text("action_add_task")
+                                        Spacer()
+                                        Image(systemName: "plus.circle")
                                     }
-                                    Spacer()
-                                    Text(String(format: NSLocalizedString("list_tasks_count_format", comment: ""), list.tasks.count))
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
+                                    .font(.subheadline)
+                                    .foregroundColor(.accentColor)
+                                    .padding(.vertical, 4)
                                 }
-                                .textCase(nil)
-                                .contextMenu {
-                                    Button(role: .destructive) {
-                                        viewModel.delete(list: list)
-                                    } label: {
-                                        Label("action_delete_list", systemImage: "trash")
-                                    }
-                                }
+                                .listRowInsets(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
+                                .listRowBackground(Color.clear)
                             }
                         }
                         .onDelete { offsets in
                             viewModel.deleteLists(at: offsets)
                         }
                     }
-                    .listStyle(InsetGroupedListStyle())
+                    .listStyle(PlainListStyle())
+                    .background(Color(.systemGroupedBackground))
                 }
             }
             .navigationTitle(Text("lists_title"))
@@ -178,6 +165,35 @@ struct TaskListView: View {
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
+    }
+}
+
+private extension TaskListView {
+    func header(for list: TaskList) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(list.name)
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                Spacer()
+                Text(String(format: NSLocalizedString("list_tasks_count_format", comment: ""), list.tasks.count))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Text(LocalizedStringKey(list.category.localizationKey))
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 8)
+        .textCase(nil)
+        .contextMenu {
+            Button(role: .destructive) {
+                viewModel.delete(list: list)
+            } label: {
+                Label("action_delete_list", systemImage: "trash")
+            }
+        }
     }
 }
 

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskRowView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskRowView.swift
@@ -14,7 +14,7 @@ struct TaskRowView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .firstTextBaseline) {
                 Text(task.title)
                     .font(.headline)
@@ -59,11 +59,13 @@ struct TaskRowView: View {
                 .clipShape(Capsule())
                 .accessibilityLabel(Text(LocalizedStringKey(task.category.localizationKey)))
         }
-        .padding(16)
+        .padding(.vertical, 20)
+        .padding(.horizontal, 24)
         .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
                 .fill(Color(.secondarySystemBackground))
         )
+        .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 4)
     }
 }
 

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskRowView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskRowView.swift
@@ -9,43 +9,61 @@ struct TaskRowView: View {
         return formatter
     }()
 
-    var body: some View {
-        HStack(spacing: 16) {
-            Image(systemName: task.iconName)
-                .font(.system(size: 28))
-                .foregroundColor(task.status == .completed ? .green : .accentColor)
-                .accessibilityHidden(true)
+    private var statusColor: Color {
+        task.status == .completed ? .green : .orange
+    }
 
-            VStack(alignment: .leading, spacing: 6) {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
                 Text(task.title)
                     .font(.headline)
+                    .foregroundColor(.primary)
 
+                Spacer()
+
+                Text(task.status.localizationKey)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(statusColor)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(statusColor.opacity(0.15))
+                    .clipShape(Capsule())
+            }
+
+            Text(task.details)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+
+            HStack {
                 Text(task.listName)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-
-                HStack(spacing: 8) {
-                    Label {
-                        Text(LocalizedStringKey(task.category.localizationKey))
-                    } icon: {
-                        Image(systemName: task.category.iconName)
-                    }
                     .font(.caption)
                     .foregroundColor(.secondary)
 
-                    Text(dateFormatter.string(from: task.dueDate))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+                Spacer()
+
+                Text(dateFormatter.string(from: task.dueDate))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
             }
 
-            Spacer()
-
-            Image(systemName: task.status == .completed ? "checkmark.circle.fill" : "clock")
-                .foregroundColor(task.status == .completed ? .green : .orange)
-                .accessibilityLabel(Text(task.status.localizationKey))
+            Text(LocalizedStringKey(task.category.localizationKey))
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundColor(.accentColor)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(Color.accentColor.opacity(0.12))
+                .clipShape(Capsule())
+                .accessibilityLabel(Text(LocalizedStringKey(task.category.localizationKey)))
         }
-        .padding(.vertical, 8)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
     }
 }
 
@@ -63,7 +81,8 @@ struct TaskRowView_Previews: PreviewProvider {
                 category: .work
             )
         )
-        .previewLayout(.sizeThatFits)
         .padding()
+        .background(Color(.systemGroupedBackground))
+        .previewLayout(.sizeThatFits)
     }
 }

--- a/TodoListApp/TodoListApp/src/presentation/views/TaskRowView.swift
+++ b/TodoListApp/TodoListApp/src/presentation/views/TaskRowView.swift
@@ -14,7 +14,7 @@ struct TaskRowView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 18) {
             HStack(alignment: .firstTextBaseline) {
                 Text(task.title)
                     .font(.headline)
@@ -32,10 +32,14 @@ struct TaskRowView: View {
                     .clipShape(Capsule())
             }
 
-            Text(task.details)
-                .font(.subheadline)
-                .foregroundColor(.secondary)
-                .lineLimit(2)
+            VStack(alignment: .leading, spacing: 6) {
+                fieldLabel("task_row_description_label")
+
+                Text(task.details)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+            }
 
             HStack {
                 Text(task.listName)
@@ -44,20 +48,29 @@ struct TaskRowView: View {
 
                 Spacer()
 
-                Text(dateFormatter.string(from: task.dueDate))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                VStack(alignment: .trailing, spacing: 6) {
+                    fieldLabel("task_row_date_label")
+                        .multilineTextAlignment(.trailing)
+
+                    Text(dateFormatter.string(from: task.dueDate))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
             }
 
-            Text(LocalizedStringKey(task.category.localizationKey))
-                .font(.caption)
-                .fontWeight(.medium)
-                .foregroundColor(.accentColor)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 4)
-                .background(Color.accentColor.opacity(0.12))
-                .clipShape(Capsule())
-                .accessibilityLabel(Text(LocalizedStringKey(task.category.localizationKey)))
+            VStack(alignment: .leading, spacing: 6) {
+                fieldLabel("task_row_category_label")
+
+                Text(LocalizedStringKey(task.category.localizationKey))
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundColor(.accentColor)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(Color.accentColor.opacity(0.12))
+                    .clipShape(Capsule())
+                    .accessibilityLabel(Text(LocalizedStringKey(task.category.localizationKey)))
+            }
         }
         .padding(.vertical, 20)
         .padding(.horizontal, 24)
@@ -66,6 +79,12 @@ struct TaskRowView: View {
                 .fill(Color(.secondarySystemBackground))
         )
         .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 4)
+    }
+
+    private func fieldLabel(_ title: LocalizedStringKey) -> some View {
+        Text(title)
+            .font(.caption)
+            .foregroundColor(.secondary)
     }
 }
 

--- a/TodoListApp/TodoListAppTests/CoreDataTaskListDataSourceTests.swift
+++ b/TodoListApp/TodoListAppTests/CoreDataTaskListDataSourceTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+import CoreData
+@testable import TodoListApp
+
+final class CoreDataTaskListDataSourceTests: XCTestCase {
+    private var persistence: PersistenceController!
+    private var dataSource: CoreDataTaskListDataSource!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        persistence = PersistenceController(inMemory: true)
+        dataSource = CoreDataTaskListDataSource(context: persistence.container.viewContext)
+    }
+
+    override func tearDownWithError() throws {
+        dataSource = nil
+        persistence = nil
+        try super.tearDownWithError()
+    }
+
+    func testAddListPersistsList() throws {
+        let identifier = UUID()
+        let list = TaskListDataModel(
+            identifier: identifier,
+            name: "Today",
+            categoryRaw: TaskCategory.work.rawValue,
+            tasks: []
+        )
+
+        try dataSource.add(list: list)
+
+        let storedLists = try dataSource.fetchLists()
+        XCTAssertEqual(storedLists.count, 1)
+        XCTAssertEqual(storedLists.first?.identifier, identifier)
+    }
+
+    func testAddTaskWithoutListThrows() {
+        let task = TaskDataModel(
+            iconName: "checkmark",
+            title: "Review",
+            details: "Weekly review",
+            dueDate: Date(),
+            statusRaw: TaskStatus.pending.rawValue,
+            listIdentifier: UUID(),
+            listName: "Planning",
+            categoryRaw: TaskCategory.work.rawValue
+        )
+
+        XCTAssertThrowsError(try dataSource.add(task: task)) { error in
+            guard case TaskDataSourceError.listNotFound = error as? TaskDataSourceError else {
+                return XCTFail("Expected listNotFound error")
+            }
+        }
+    }
+
+    func testUpdateTaskChangesPersistedValues() throws {
+        let list = TaskListDataModel(
+            identifier: UUID(),
+            name: "Personal",
+            categoryRaw: TaskCategory.personal.rawValue,
+            tasks: []
+        )
+        try dataSource.add(list: list)
+
+        let task = TaskDataModel(
+            iconName: "sun.max",
+            title: "Meditate",
+            details: "Take ten minutes",
+            dueDate: Date(),
+            statusRaw: TaskStatus.pending.rawValue,
+            listIdentifier: list.identifier,
+            listName: list.name,
+            categoryRaw: TaskCategory.personal.rawValue
+        )
+        try dataSource.add(task: task)
+
+        var updatedTask = task
+        updatedTask.title = "Meditate deeply"
+        updatedTask.statusRaw = TaskStatus.completed.rawValue
+        try dataSource.update(task: updatedTask)
+
+        let storedTask = try dataSource.getTask(by: task.identifier)
+        XCTAssertEqual(storedTask?.title, "Meditate deeply")
+        XCTAssertEqual(storedTask?.statusRaw, TaskStatus.completed.rawValue)
+    }
+
+    func testEnsureInitialDataSeedsEmptyStore() throws {
+        try dataSource.ensureInitialData {
+            let listID = UUID()
+            let task = TaskDataModel(
+                iconName: "calendar",
+                title: "Plan",
+                details: "Plan the week",
+                dueDate: Date(),
+                statusRaw: TaskStatus.pending.rawValue,
+                listIdentifier: listID,
+                listName: "Planning",
+                categoryRaw: TaskCategory.work.rawValue
+            )
+
+            return [TaskListDataModel(
+                identifier: listID,
+                name: "Planning",
+                categoryRaw: TaskCategory.work.rawValue,
+                tasks: [task]
+            )]
+        }
+
+        let storedLists = try dataSource.fetchLists()
+        XCTAssertEqual(storedLists.count, 1)
+        XCTAssertEqual(storedLists.first?.tasks.count, 1)
+    }
+}

--- a/TodoListApp/TodoListAppTests/LanguageControllerTests.swift
+++ b/TodoListApp/TodoListAppTests/LanguageControllerTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import TodoListApp
+
+final class LanguageControllerTests: XCTestCase {
+    private let suiteName = "LanguageControllerTests"
+    private var userDefaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Unable to create UserDefaults with custom suite.")
+        }
+        userDefaults = defaults
+        userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        userDefaults?.removePersistentDomain(forName: suiteName)
+        userDefaults = nil
+        try super.tearDownWithError()
+    }
+
+    func testInitializesWithStoredLanguage() {
+        userDefaults.set(AppLanguage.spanish.rawValue, forKey: "selectedLanguage")
+
+        let controller = LanguageController(storage: userDefaults)
+
+        XCTAssertEqual(controller.currentLanguage, .spanish)
+    }
+
+    func testUpdateLanguagePersistsSelection() {
+        let controller = LanguageController(storage: userDefaults)
+
+        controller.updateLanguage(.spanish)
+
+        XCTAssertEqual(controller.currentLanguage, .spanish)
+        XCTAssertEqual(userDefaults.string(forKey: "selectedLanguage"), AppLanguage.spanish.rawValue)
+    }
+
+    func testUpdateLanguageDoesNotPersistWhenSameLanguage() {
+        let controller = LanguageController(storage: userDefaults)
+
+        controller.updateLanguage(controller.currentLanguage)
+
+        XCTAssertNil(userDefaults.string(forKey: "selectedLanguage"))
+    }
+}

--- a/TodoListApp/TodoListAppTests/TaskDataSourceErrorTests.swift
+++ b/TodoListApp/TodoListAppTests/TaskDataSourceErrorTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import TodoListApp
+
+final class TaskDataSourceErrorTests: XCTestCase {
+    func testListNotFoundLocalizedDescription() {
+        let error = TaskDataSourceError.listNotFound
+        XCTAssertEqual(error.errorDescription, NSLocalizedString("error_list_not_found", comment: ""))
+    }
+
+    func testTaskNotFoundLocalizedDescription() {
+        let error = TaskDataSourceError.taskNotFound
+        XCTAssertEqual(error.errorDescription, NSLocalizedString("error_task_not_found", comment: ""))
+    }
+
+    func testUnknownErrorLocalizedDescription() {
+        let error = TaskDataSourceError.unknown
+        XCTAssertEqual(error.errorDescription, NSLocalizedString("error_unknown", comment: ""))
+    }
+}

--- a/TodoListApp/TodoListAppTests/TaskDomainModelTests.swift
+++ b/TodoListApp/TodoListAppTests/TaskDomainModelTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import TodoListApp
+
+final class TaskDomainModelTests: XCTestCase {
+    func testTaskCategoryLocalizationKeys() {
+        XCTAssertEqual(TaskCategory.work.localizationKey, "category_work")
+        XCTAssertEqual(TaskCategory.shopping.localizationKey, "category_shopping")
+        XCTAssertEqual(TaskCategory.leisure.localizationKey, "category_leisure")
+        XCTAssertEqual(TaskCategory.personal.localizationKey, "category_personal")
+        XCTAssertEqual(TaskCategory.health.localizationKey, "category_health")
+        XCTAssertEqual(TaskCategory.errands.localizationKey, "category_errands")
+    }
+
+    func testTaskCategoryIconNames() {
+        XCTAssertEqual(TaskCategory.work.iconName, "briefcase.fill")
+        XCTAssertEqual(TaskCategory.shopping.iconName, "cart.fill")
+        XCTAssertEqual(TaskCategory.leisure.iconName, "gamecontroller.fill")
+        XCTAssertEqual(TaskCategory.personal.iconName, "person.crop.circle.fill")
+        XCTAssertEqual(TaskCategory.health.iconName, "heart.fill")
+        XCTAssertEqual(TaskCategory.errands.iconName, "checklist")
+    }
+
+    func testTaskStatusLocalization() {
+        XCTAssertEqual(TaskStatus.pending.localizationKey, NSLocalizedString("task_status_pending", comment: ""))
+        XCTAssertEqual(TaskStatus.completed.localizationKey, NSLocalizedString("task_status_completed", comment: ""))
+    }
+
+    func testTaskEqualityComparesAllProperties() {
+        let dueDate = Date()
+        let firstTask = Task(
+            iconName: "calendar",
+            title: "Plan",
+            details: "Plan tasks",
+            dueDate: dueDate,
+            status: .pending,
+            listID: UUID(),
+            listName: "Work",
+            category: .work
+        )
+
+        var modifiedTask = firstTask
+        modifiedTask.title = "Plan more"
+
+        XCTAssertNotEqual(firstTask, modifiedTask)
+    }
+
+    func testTaskListInitializesWithEmptyTasks() {
+        let list = TaskList(name: "Inbox", category: .work)
+        XCTAssertTrue(list.tasks.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for data, domain and presentation utilities including Core Data data source and language controller
- refresh task list, detail and form screens with a cleaner minimalist layout

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dec40173dc8329a561071a7bc42ca0